### PR TITLE
Increase white space for submit review button

### DIFF
--- a/web/public/review.css
+++ b/web/public/review.css
@@ -101,7 +101,7 @@ h1 > small {
 }
 
 #main_action {
-  margin-top: 30px;
+  margin: 30px 0;
 }
 
 #no_audio h5 {


### PR DESCRIPTION
There was no bottom margin set for the submit button in the video review page. Because of this, the version information was showing way too close to the button. I've added 30px of margin below
the button, to give a bit of space to the version info.

PS: my first PR! :)

Signed-off-by: Belen Pena <belenbarrospena@gmail.com>