### PR TITLE
Fix length(undef) warning in get_metadata

### DIFF
--- a/lib/SReview/Talk.pm
+++ b/lib/SReview/Talk.pm
@@ -1095,7 +1095,7 @@ sub get_metadata {
                 if($@) {
                         delete $rv->{$metadata};
                 }
-                if(length($rv->{$metadata}) == 0) {
+                elsif(length($rv->{$metadata}) == 0) {
                         delete $rv->{$metadata};
                 }
         }


### PR DESCRIPTION
After deleting a hash key on eval failure, the next if-block called length() on the now-undef value. Change to elsif to skip the check when the key was already deleted.